### PR TITLE
chore: remove poetry export pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,14 +35,6 @@ repos:
     rev: 1.8.4
     hooks:
       - id: poetry-check
-      - id: poetry-export
-        args:
-          [
-            "--without-hashes",
-            "--only=dev",
-            "--format=requirements.txt",
-            "--output=requirements-dev.txt",
-          ]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:


### PR DESCRIPTION
### Description of change

Remove unused pre-commit hook. Was switched to running poetry export on CI. 

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/django-admin-helpers/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
