### PR TITLE
feat: add option to `delete_remaked_migrations` to delete old migration files

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,7 +50,7 @@ Want to know more about how it works? Read the {ref}`technical details page <tec
 
 ## Cleaning up remaked migrations
 
-After you've deployed the remaked migrations to all your environments (development, staging, production), the `replaces` attribute in the migration files is no longer necessary. You can clean it up using the `delete_remaked_migrations` command.
+After you've deployed the remaked migrations to all your environments (development, staging, production), the `replaces` attribute in the migration files is no longer necessary, along the old migration files (if you kept them). You can clean it up using the `delete_remaked_migrations` command.
 
 ```{caution}
 Only run this command after you're certain that all your environments have applied the remaked migrations!
@@ -70,6 +70,8 @@ You may choose to clean up only a specific app:
 python manage.py delete_remaked_migrations --app-label myapp
 ```
 
+If you remade the migrations with the `--keep-old-migrations` option, you can also remove the old migration files by adding `--remove-replaced`, which will both delete the old files and remove the `replaces` attribute from the remade migrations.
+
 ### What does it do?
 
 The command:
@@ -77,5 +79,6 @@ The command:
 1. Finds all migration files with `_remaked_` in their name (from first-party apps only)
 2. Removes the `replaces` attribute from each file
 3. Keeps everything else intact (including `initial = True`)
+4. Removes old migration files if `--remove-replaced` is set
 
 This simplifies the migration files, and unmark them as squashed.

--- a/src/django_remake_migrations/management/commands/delete_remaked_migrations.py
+++ b/src/django_remake_migrations/management/commands/delete_remaked_migrations.py
@@ -31,6 +31,7 @@ class Command(BaseCommand):
     - Remove only the `replaces` attribute from each file
     - Keep all other attributes (like `initial = True`) intact
     - Only process first-party apps (not site-packages/dist-packages)
+    - Optionally delete the replaced migrations (--remove-replaced)
 
     You need to ensure that the remaked migrations are fully rolled out everywhere
     before deploying the result of this command.
@@ -38,7 +39,8 @@ class Command(BaseCommand):
 
     help = (
         "Remove the 'replaces' attribute from remaked migrations after they've been "
-        "fully deployed to all environments."
+        "fully deployed to all environments. Optionally also deletes "
+        "the replaced migrations."
     )
 
     def add_arguments(self, parser: ArgumentParser) -> None:
@@ -54,12 +56,19 @@ class Command(BaseCommand):
             dest="app_label",
             help="Only process migrations for the specified app.",
         )
+        parser.add_argument(
+            "--remove-replaced",
+            dest="remove_replaced",
+            action="store_true",
+            help="Remove the files containing the replaced migrations",
+        )
 
     def handle(
         self,
         *args: str,
         dry_run: bool = False,
         app_label: str | None = None,
+        remove_replaced: bool = False,
         **options: Any,
     ) -> None:
         """Command entry point."""
@@ -82,16 +91,38 @@ class Command(BaseCommand):
 
         # Process each migration
         success_count = 0
+        deleted_migrations: set[tuple[str, str]] = set()
 
         for app, migrations in sorted(remaked_migrations.items()):
             for _, migration_name, file_path, migration_module in migrations:
-                if self.remove_replaces_from_file(file_path, migration_module, dry_run):
+                remove_result, replaces = self.remove_replaces_from_file(
+                    file_path,
+                    migration_module,
+                    dry_run=dry_run,
+                    remove_replaced=remove_replaced,
+                )
+
+                if remove_result:
                     if dry_run:
                         self.stdout.write(
                             f"Would remove replaces from: {app}.{migration_name}"
                         )
+                        if remove_replaced:
+                            deleted_migrations.update(replaces)
+                            for to_remove in replaces:
+                                self.stdout.write(
+                                    f"  - would delete migration "
+                                    f"{to_remove[1]!r} from app {to_remove[0]!r}"
+                                )
                     else:
                         self.log_info(f"Removed replaces from: {app}.{migration_name}")
+                        if remove_replaced:
+                            deleted_migrations.update(replaces)
+                            for to_remove in replaces:
+                                self.stdout.write(
+                                    f"  - deleted migration "
+                                    f"{to_remove[1]!r} from app {to_remove[0]!r}"
+                                )
                     success_count += 1
                 else:
                     self.stdout.write(
@@ -102,12 +133,12 @@ class Command(BaseCommand):
 
         # Final summary
         self.stdout.write("")
-        if dry_run:
-            self.log_info(
-                f"Dry run complete. Would have processed {success_count} migration(s)."
-            )
-        else:
-            self.log_info(f"Successfully processed {success_count} migration(s).")
+
+        prefix = "Dry run complete. Would have" if dry_run else "Successfully"
+        message = f"{prefix} processed {success_count} migration(s)"
+        if remove_replaced:
+            message += f" and deleted {len(deleted_migrations)} migration(s)"
+        self.log_info(message)
 
     def find_remaked_migrations(
         self, app_label: str | None = None
@@ -155,8 +186,12 @@ class Command(BaseCommand):
         return dict(remaked_migrations)
 
     def remove_replaces_from_file(
-        self, file_path: Path, migration_module: ModuleType, dry_run: bool = False
-    ) -> bool:
+        self,
+        file_path: Path,
+        migration_module: ModuleType,
+        dry_run: bool = False,
+        remove_replaced: bool = False,
+    ) -> tuple[bool, list[tuple[str, str]]]:
         """
         Remove the replaces attribute from a migration file.
 
@@ -171,10 +206,12 @@ class Command(BaseCommand):
         migration: Migration = migration_module.Migration
 
         if not migration.replaces:
-            return False
+            return False, []
 
         if dry_run:
-            return True
+            return True, migration.replaces
+
+        replaces = list(migration.replaces)
 
         migration.replaces = None
 
@@ -182,7 +219,25 @@ class Command(BaseCommand):
         with file_path.open("w", encoding="utf-8") as fh:
             fh.write(writer.as_string())
 
-        return True
+        removed = replaces
+        if remove_replaced:
+            removed = []
+            for app_label, migration_name in replaces:
+                app_migrations_module_name, _ = MigrationLoader.migrations_module(
+                    app_label
+                )
+                try:
+                    migration_module = import_module(
+                        f"{app_migrations_module_name}.{migration_name}"
+                    )
+                except ModuleNotFoundError:  # already is deleted
+                    continue
+                migration_file = Path(migration_module.__file__)  # type: ignore[arg-type]
+                if migration_file.exists():
+                    migration_file.unlink()
+                    removed.append((app_label, migration_name))
+
+        return True, removed
 
     @staticmethod
     def _is_first_party(app_config: AppConfig) -> bool:

--- a/src/django_remake_migrations/management/commands/delete_remaked_migrations.py
+++ b/src/django_remake_migrations/management/commands/delete_remaked_migrations.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-import re
+import types
 from argparse import ArgumentParser
 from collections import defaultdict
 from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 from django.apps import AppConfig, apps
 from django.core.management import BaseCommand
+from django.db.migrations import Migration
+from django.db.migrations.exceptions import BadMigrationError
 from django.db.migrations.loader import MigrationLoader
+
+from django_remake_migrations.management.migration_writer import CustomMigrationWriter
 
 
 class Command(BaseCommand):
@@ -79,8 +84,8 @@ class Command(BaseCommand):
         success_count = 0
 
         for app, migrations in sorted(remaked_migrations.items()):
-            for _, migration_name, file_path in migrations:
-                if self.remove_replaces_from_file(file_path, dry_run):
+            for _, migration_name, file_path, migration_module in migrations:
+                if self.remove_replaces_from_file(file_path, migration_module, dry_run):
                     if dry_run:
                         self.stdout.write(
                             f"Would remove replaces from: {app}.{migration_name}"
@@ -106,7 +111,7 @@ class Command(BaseCommand):
 
     def find_remaked_migrations(
         self, app_label: str | None = None
-    ) -> dict[str, list[tuple[str, str, Path]]]:
+    ) -> dict[str, list[tuple[str, str, Path, types.ModuleType]]]:
         """
         Find all remaked migration files.
 
@@ -144,12 +149,14 @@ class Command(BaseCommand):
             )
             migration_file = Path(migration_module.__file__)  # type: ignore[arg-type]
             remaked_migrations[app_label_iter].append(
-                (app_label_iter, migration_name, migration_file)
+                (app_label_iter, migration_name, migration_file, migration_module)
             )
 
         return dict(remaked_migrations)
 
-    def remove_replaces_from_file(self, file_path: Path, dry_run: bool = False) -> bool:
+    def remove_replaces_from_file(
+        self, file_path: Path, migration_module: ModuleType, dry_run: bool = False
+    ) -> bool:
         """
         Remove the replaces attribute from a migration file.
 
@@ -157,39 +164,24 @@ class Command(BaseCommand):
             True if replaces was found and removed, False otherwise
 
         """
-        content = file_path.read_text(encoding="utf-8")
+        if not hasattr(migration_module, "Migration"):
+            raise BadMigrationError(
+                f"Migration {migration_module} has no Migration class"
+            )
+        migration: Migration = migration_module.Migration
 
-        new_lines = []
-        modified = False
-        in_replaces = False
-
-        for line in content.split("\n"):
-            # Check if this line starts a replaces assignment
-            if re.match(r"^\s*replaces\s*=\s*\[", line):
-                modified = True
-                # Check if it's complete on one line
-                if line.rstrip().endswith("]"):
-                    continue  # Skip this line completely
-                else:
-                    in_replaces = True
-                    continue
-
-            # If we're in a multi-line replaces, skip until we find the closing bracket
-            if in_replaces:
-                if "]" in line:
-                    in_replaces = False
-                continue
-
-            new_lines.append(line)
-
-        if not modified:
+        if not migration.replaces:
             return False
 
         if dry_run:
             return True
 
-        new_content = "\n".join(new_lines)
-        file_path.write_text(new_content, encoding="utf-8")
+        migration.replaces = None
+
+        writer = CustomMigrationWriter(migration)
+        with file_path.open("w", encoding="utf-8") as fh:
+            fh.write(writer.as_string())
+
         return True
 
     @staticmethod

--- a/src/django_remake_migrations/management/commands/remakemigrations.py
+++ b/src/django_remake_migrations/management/commands/remakemigrations.py
@@ -12,33 +12,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import BaseCommand, call_command
 from django.db.migrations import Migration
 from django.db.migrations.loader import MigrationLoader
-from django.db.migrations.writer import MigrationWriter
 from django.utils.module_loading import import_string
 
 from django_remake_migrations.conf import app_settings
-
-
-class CustomMigrationWriter(MigrationWriter):
-    """
-    Custom MigrationWriter which adds support for ``run_before``.
-
-    There's a ticket and a PR in Django itself to add support for this.
-    If that's merged in and released, we can remove this subclass when
-    new versions of Django are installed.
-    - https://code.djangoproject.com/ticket/36274
-    - https://github.com/django/django/pull/19303.
-    """
-
-    def as_string(self) -> str:
-        """Add run_before if available."""
-        text = super().as_string()
-        if self.migration.run_before:
-            run_before_string = f"run_before = {self.migration.run_before}"
-            text = text.replace(
-                "class Migration(migrations.Migration):",
-                f"class Migration(migrations.Migration):\n    {run_before_string}",
-            )
-        return text
+from django_remake_migrations.management.migration_writer import CustomMigrationWriter
 
 
 class Command(BaseCommand):

--- a/src/django_remake_migrations/management/migration_writer.py
+++ b/src/django_remake_migrations/management/migration_writer.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from django.db.migrations.writer import MigrationWriter
+
+
+class CustomMigrationWriter(MigrationWriter):
+    """
+    Custom MigrationWriter which adds support for ``run_before``.
+
+    There's a ticket and a PR in Django itself to add support for this.
+    If that's merged in and released, we can remove this subclass when
+    new versions of Django are installed.
+    - https://code.djangoproject.com/ticket/36274
+    - https://github.com/django/django/pull/19303.
+    """
+
+    def as_string(self) -> str:
+        """Add run_before if available."""
+        text = super().as_string()
+        if self.migration.run_before:
+            run_before_string = f"run_before = {self.migration.run_before}"
+            text = text.replace(
+                "class Migration(migrations.Migration):",
+                f"class Migration(migrations.Migration):\n    {run_before_string}",
+            )
+        return text

--- a/tests/test_delete_remaked_migrations.py
+++ b/tests/test_delete_remaked_migrations.py
@@ -96,7 +96,7 @@ class TestDeleteRemakedMigrations(TestCase):
         content = mig_file.read_text()
         assert "replaces" not in content
         assert "initial = True" in content  # Should still be present
-        assert "operations = []" in content  # Other content intact
+        assert "operations = [\n    ]" in content  # Other content intact
         assert "class Migration(migrations.Migration):" in content
 
     def test_multiple_apps(self):
@@ -233,7 +233,7 @@ class TestDeleteRemakedMigrations(TestCase):
         assert "0001_old" not in content
         assert "0002_old" not in content
         assert "initial = True" in content
-        assert "operations = []" in content
+        assert "operations = [\n    ]" in content
 
     def test_multiple_migrations_same_app(self):
         """Test handling multiple remaked migrations in the same app."""

--- a/tests/test_delete_remaked_migrations.py
+++ b/tests/test_delete_remaked_migrations.py
@@ -11,6 +11,25 @@ from django.test import TestCase
 from tests.utils import run_command, setup_test_apps
 
 
+def create_old_migration(mig_dir: Path, name: str) -> Path:
+    """Helper to create an old migration file."""
+    filename = f"{name}.py"
+    file_path = mig_dir / filename
+    content = dedent("""\
+        from django.db import migrations
+
+
+        class Migration(migrations.Migration):
+            initial = True
+
+            dependencies = []
+
+            operations = []
+    """)
+    file_path.write_text(content)
+    return file_path
+
+
 def create_remaked_migration(
     mig_dir: Path,
     name: str,
@@ -285,3 +304,82 @@ class TestDeleteRemakedMigrations(TestCase):
         # Only remaked migration should be modified
         assert "replaces" not in remaked_mig.read_text()
         assert "replaces" in regular_mig.read_text()  # Regular migration untouched
+
+    def test_remove_replaced(self):
+        """Test removing replaces with deleting replaced migrations."""
+        app1_mig_dir = self.app_mig_dirs["app1"]
+        (app1_mig_dir / "__init__.py").touch()
+
+        mig_file = create_remaked_migration(app1_mig_dir, "0001", has_replaces=True)
+        old_file_01 = create_old_migration(app1_mig_dir, "0001_old")
+        old_file_02 = create_old_migration(app1_mig_dir, "0002_old")
+
+        out, err, returncode = run_command(
+            "delete_remaked_migrations", remove_replaced=True
+        )
+
+        assert returncode == 0
+        assert "Successfully processed 1 migration(s) and deleted 2 migration(s)" in out
+        assert err == ""
+
+        # Verify replaces was removed
+        content = mig_file.read_text()
+        assert "replaces" not in content
+        assert "initial = True" in content  # Should still be present
+        assert "operations = [\n    ]" in content  # Other content intact
+        assert "class Migration(migrations.Migration):" in content
+
+        assert old_file_01.exists() is False
+        assert old_file_02.exists() is False
+
+    def test_remove_replaced_dry_run(self):
+        """Test dry-run replaces with deleting replaced migrations."""
+        app1_mig_dir = self.app_mig_dirs["app1"]
+        (app1_mig_dir / "__init__.py").touch()
+
+        mig_file = create_remaked_migration(app1_mig_dir, "0001", has_replaces=True)
+        old_file_01 = create_old_migration(app1_mig_dir, "0001_old")
+        old_file_02 = create_old_migration(app1_mig_dir, "0002_old")
+
+        out, err, returncode = run_command(
+            "delete_remaked_migrations", remove_replaced=True, dry_run=True
+        )
+
+        assert returncode == 0
+        assert (
+            "Dry run complete. Would have processed 1 "
+            "migration(s) and deleted 2 migration(s)" in out
+        )
+        assert err == ""
+
+        # Verify replaces was removed
+        content = mig_file.read_text()
+        assert "replaces" in content
+
+        assert old_file_01.exists() is True
+        assert old_file_02.exists() is True
+
+    def test_remove_replaced_missing(self):
+        """Test removing replaces with deleting replaced migrations."""
+        app1_mig_dir = self.app_mig_dirs["app1"]
+        (app1_mig_dir / "__init__.py").touch()
+
+        mig_file = create_remaked_migration(app1_mig_dir, "0001", has_replaces=True)
+        old_file_01 = create_old_migration(app1_mig_dir, "0001_old")
+
+        out, err, returncode = run_command(
+            "delete_remaked_migrations", remove_replaced=True
+        )
+
+        assert returncode == 0
+        assert "Successfully processed 1 migration(s) and deleted 1 migration(s)" in out
+        assert err == ""
+
+        # Verify replaces was removed
+        content = mig_file.read_text()
+        assert "replaces" not in content
+        assert "initial = True" in content  # Should still be present
+        assert "operations = [\n    ]" in content  # Other content intact
+        assert "class Migration(migrations.Migration):" in content
+
+        assert old_file_01.exists() is False


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/browniebroke/django-admin-helpers/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

I do love the addition of the `delete_remaked_migrations` command, it has always been a bit annoying to do it (https://django-extensions.readthedocs.io/en/latest/delete_squashed_migrations.html does not support multi-line replaces).

As I have highlighted in https://github.com/browniebroke/django-remake-migrations/pull/419, we keep the old migrations around for a few weeks to give all devs the ability to bring their env up to date, and only then we remove the migration. As such, I have added a option to `delete_remaked_options` to delete the old migrations.

To do that, I need to have the list of old migration files  which is listed in the migration, which would require me to parse the file, so I replaced the whole `remove_replaces_from_file` method with parsing using the django migration framework, and writing it back to file using the CustomMigrationWriter I added recently in https://github.com/browniebroke/django-remake-migrations/pull/434.

Let me know what you think!
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/django-admin-helpers/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
